### PR TITLE
Refactor protocol configuration to support multiple measurement provi…

### DIFF
--- a/src/prisma/migrations/20260629120000_change_measurement_provider_to_array/migration.sql
+++ b/src/prisma/migrations/20260629120000_change_measurement_provider_to_array/migration.sql
@@ -1,0 +1,43 @@
+-- Convert measurement_provider (single string, incl. legacy 'both') into
+-- measurement_providers (string[]). Data-preserving: ADD -> backfill -> DROP in one
+-- migration so Prisma does not emit a destructive DROP+ADD.
+--
+-- NOTE: the new columns are intentionally created WITHOUT NOT NULL / DEFAULT, to match
+-- exactly how Prisma renders a `String[] @db.VarChar(32)` field (see precedent
+-- `category_config.allowedCountries TEXT[]`). Adding constraints here would make the
+-- next `prisma migrate dev --create-only` emit a non-empty drift migration.
+-- Semantics: empty array ([]) / NULL means "inherit from country / default"; the
+-- service (coerceProviders) normalizes both to []. The universal default is ['mlab'].
+
+-- country_protocol_config: 'both'->['mlab','cloudflare'], else single-element array,
+-- unknown/invalid -> ['mlab'] (mirrors coerceProviders fallback).
+ALTER TABLE "country_protocol_config" ADD COLUMN "measurement_providers" VARCHAR(32)[];
+
+UPDATE "country_protocol_config"
+SET "measurement_providers" =
+  CASE lower(trim("measurement_provider"))
+    WHEN 'both'       THEN ARRAY['mlab', 'cloudflare']::VARCHAR(32)[]
+    WHEN 'cloudflare' THEN ARRAY['cloudflare']::VARCHAR(32)[]
+    WHEN 'mlab'       THEN ARRAY['mlab']::VARCHAR(32)[]
+    ELSE ARRAY['mlab']::VARCHAR(32)[]
+  END;
+
+ALTER TABLE "country_protocol_config" DROP COLUMN "measurement_provider";
+
+-- school_protocol_config: NULL (inherits) -> [] ; same mapping otherwise.
+ALTER TABLE "school_protocol_config" ADD COLUMN "measurement_providers" VARCHAR(32)[];
+
+UPDATE "school_protocol_config"
+SET "measurement_providers" =
+  CASE
+    WHEN "measurement_provider" IS NULL THEN ARRAY[]::VARCHAR(32)[]
+    ELSE
+      CASE lower(trim("measurement_provider"))
+        WHEN 'both'       THEN ARRAY['mlab', 'cloudflare']::VARCHAR(32)[]
+        WHEN 'cloudflare' THEN ARRAY['cloudflare']::VARCHAR(32)[]
+        WHEN 'mlab'       THEN ARRAY['mlab']::VARCHAR(32)[]
+        ELSE ARRAY['mlab']::VARCHAR(32)[]
+      END
+  END;
+
+ALTER TABLE "school_protocol_config" DROP COLUMN "measurement_provider";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -140,7 +140,7 @@ model country {
 model CountryProtocolConfig {
   id                      Int      @id @default(autoincrement())
   country_code            String   @unique @db.VarChar
-  measurement_provider    String   @db.VarChar(32)
+  measurement_providers   String[] @db.VarChar(32)
   between_tests_delay_sec Int      @default(0)
   created_at              DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updated_at              DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
@@ -151,11 +151,12 @@ model CountryProtocolConfig {
   @@map("country_protocol_config")
 }
 
-/// Per-school overrides for protocol (nullable fields inherit from country / default).
+/// Per-school overrides for protocol. Empty `measurement_providers` ([]) or null
+/// `between_tests_delay_sec` inherit from country / default.
 model SchoolProtocolConfig {
   id                      Int      @id @default(autoincrement())
   giga_id_school          String   @unique @db.VarChar
-  measurement_provider    String?  @db.VarChar(32)
+  measurement_providers   String[] @db.VarChar(32)
   between_tests_delay_sec Int?
   created_at              DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updated_at              DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)

--- a/src/protocol-config/protocol-config-record.dto.ts
+++ b/src/protocol-config/protocol-config-record.dto.ts
@@ -1,12 +1,19 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { MEASUREMENT_PROVIDERS, MeasurementProvider } from './protocol-config.types';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  MEASUREMENT_PROVIDERS,
+  MeasurementProvider,
+} from './protocol-config.types';
 
 export class CountryProtocolConfigRecordDto {
   @ApiProperty({ example: 'ES' })
   countryCode: string;
 
-  @ApiProperty({ enum: MEASUREMENT_PROVIDERS, example: 'mlab' })
-  measurementProvider: MeasurementProvider;
+  @ApiProperty({
+    isArray: true,
+    enum: MEASUREMENT_PROVIDERS,
+    example: ['mlab'],
+  })
+  measurementProviders: MeasurementProvider[];
 
   @ApiProperty({ example: 0 })
   betweenTestsDelaySec: number;
@@ -22,14 +29,16 @@ export class SchoolProtocolConfigRecordDto {
   @ApiProperty({ example: '5ff8f4cc-9f74-3f48-8cb1-e68e063a7c05' })
   gigaIdSchool: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
+    isArray: true,
     enum: MEASUREMENT_PROVIDERS,
-    nullable: true,
-    example: 'cloudflare',
+    description:
+      'Empty array means the school inherits from country / default.',
+    example: ['cloudflare'],
   })
-  measurementProvider: MeasurementProvider | null;
+  measurementProviders: MeasurementProvider[];
 
-  @ApiPropertyOptional({ example: 5, nullable: true })
+  @ApiProperty({ example: 5, nullable: true })
   betweenTestsDelaySec: number | null;
 
   @ApiProperty({ example: '2026-05-12T12:00:00.000Z' })

--- a/src/protocol-config/protocol-config-upsert-country.dto.ts
+++ b/src/protocol-config/protocol-config-upsert-country.dto.ts
@@ -1,14 +1,28 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsInt, Min } from 'class-validator';
-import { MEASUREMENT_PROVIDERS, MeasurementProvider } from './protocol-config.types';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsIn,
+  IsInt,
+  Min,
+} from 'class-validator';
+import {
+  MEASUREMENT_PROVIDERS,
+  MeasurementProvider,
+} from './protocol-config.types';
 
 export class UpsertCountryProtocolConfigDto {
   @ApiProperty({
+    isArray: true,
     enum: MEASUREMENT_PROVIDERS,
-    example: 'mlab',
+    example: ['mlab'],
   })
-  @IsIn(MEASUREMENT_PROVIDERS)
-  measurementProvider: MeasurementProvider;
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayUnique()
+  @IsIn(MEASUREMENT_PROVIDERS, { each: true })
+  measurementProviders: MeasurementProvider[];
 
   @ApiProperty({ example: 0, minimum: 0 })
   @IsInt()

--- a/src/protocol-config/protocol-config-upsert-school.dto.ts
+++ b/src/protocol-config/protocol-config-upsert-school.dto.ts
@@ -1,17 +1,31 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsInt, IsOptional, Min, ValidateIf } from 'class-validator';
-import { MEASUREMENT_PROVIDERS, MeasurementProvider } from './protocol-config.types';
+import {
+  ArrayUnique,
+  IsArray,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import {
+  MEASUREMENT_PROVIDERS,
+  MeasurementProvider,
+} from './protocol-config.types';
 
 export class UpsertSchoolProtocolConfigDto {
   @ApiPropertyOptional({
+    isArray: true,
     enum: MEASUREMENT_PROVIDERS,
-    nullable: true,
-    example: 'cloudflare',
+    description:
+      'Empty array clears the override (school inherits from country / default).',
+    example: ['cloudflare'],
   })
   @IsOptional()
-  @ValidateIf((_, value) => value != null)
-  @IsIn(MEASUREMENT_PROVIDERS)
-  measurementProvider?: MeasurementProvider | null;
+  @IsArray()
+  @ArrayUnique()
+  @IsIn(MEASUREMENT_PROVIDERS, { each: true })
+  measurementProviders?: MeasurementProvider[];
 
   @ApiPropertyOptional({ example: 5, minimum: 0, nullable: true })
   @IsOptional()

--- a/src/protocol-config/protocol-config.controller.ts
+++ b/src/protocol-config/protocol-config.controller.ts
@@ -68,7 +68,7 @@ export class ProtocolConfigController {
     return {
       success: true,
       data: {
-        measurementProvider: data.measurementProvider,
+        measurementProviders: data.measurementProviders,
         betweenTestsDelaySec: data.betweenTestsDelaySec,
         configSource: data.configSource,
       },
@@ -98,7 +98,10 @@ export class ProtocolConfigController {
     @Param('countryCode') countryCode: string,
     @Body() body: UpsertCountryProtocolConfigDto,
   ): Promise<ApiSuccessResponseDto<CountryProtocolConfigRecordDto>> {
-    const data = await this.protocolConfigService.upsertCountry(countryCode, body);
+    const data = await this.protocolConfigService.upsertCountry(
+      countryCode,
+      body,
+    );
     return {
       success: true,
       data,
@@ -119,7 +122,10 @@ export class ProtocolConfigController {
     required: true,
     type: String,
   })
-  @ApiResponse({ status: 200, description: 'Country protocol configuration deleted' })
+  @ApiResponse({
+    status: 200,
+    description: 'Country protocol configuration deleted',
+  })
   async deleteCountry(
     @Param('countryCode') countryCode: string,
   ): Promise<ApiSuccessResponseDto<null>> {
@@ -153,7 +159,10 @@ export class ProtocolConfigController {
     @Param('gigaIdSchool') gigaIdSchool: string,
     @Body() body: UpsertSchoolProtocolConfigDto,
   ): Promise<ApiSuccessResponseDto<SchoolProtocolConfigRecordDto>> {
-    const data = await this.protocolConfigService.upsertSchool(gigaIdSchool, body);
+    const data = await this.protocolConfigService.upsertSchool(
+      gigaIdSchool,
+      body,
+    );
     return {
       success: true,
       data,
@@ -174,7 +183,10 @@ export class ProtocolConfigController {
     required: true,
     type: String,
   })
-  @ApiResponse({ status: 200, description: 'School protocol configuration deleted' })
+  @ApiResponse({
+    status: 200,
+    description: 'School protocol configuration deleted',
+  })
   async deleteSchool(
     @Param('gigaIdSchool') gigaIdSchool: string,
   ): Promise<ApiSuccessResponseDto<null>> {

--- a/src/protocol-config/protocol-config.dto.ts
+++ b/src/protocol-config/protocol-config.dto.ts
@@ -3,10 +3,11 @@ import { MEASUREMENT_PROVIDERS } from './protocol-config.types';
 
 export class ResolvedProtocolConfigDto {
   @ApiProperty({
+    isArray: true,
     enum: MEASUREMENT_PROVIDERS,
-    example: 'mlab',
+    example: ['mlab'],
   })
-  measurementProvider: string;
+  measurementProviders: string[];
 
   @ApiProperty({ example: 0 })
   betweenTestsDelaySec: number;

--- a/src/protocol-config/protocol-config.service.spec.ts
+++ b/src/protocol-config/protocol-config.service.spec.ts
@@ -39,40 +39,46 @@ describe('ProtocolConfigService', () => {
     expect(service).toBeDefined();
   });
 
-  it('returns default when no rows', async () => {
-    jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue(null);
-    jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue(null);
+  it('returns default (mlab) when no rows', async () => {
+    jest
+      .spyOn(prisma.schoolProtocolConfig, 'findUnique')
+      .mockResolvedValue(null);
+    jest
+      .spyOn(prisma.countryProtocolConfig, 'findUnique')
+      .mockResolvedValue(null);
 
     await expect(service.resolve('g1', 'ZZ')).resolves.toEqual({
-      measurementProvider: 'mlab',
+      measurementProviders: ['mlab'],
       betweenTestsDelaySec: 0,
       configSource: 'default',
     });
   });
 
   it('uses country when present', async () => {
-    jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue(null);
+    jest
+      .spyOn(prisma.schoolProtocolConfig, 'findUnique')
+      .mockResolvedValue(null);
     jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue({
       id: 1,
       country_code: 'BR',
-      measurement_provider: 'cloudflare',
+      measurement_providers: ['cloudflare'],
       between_tests_delay_sec: 10,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
     await expect(service.resolve(undefined, 'BR')).resolves.toEqual({
-      measurementProvider: 'cloudflare',
+      measurementProviders: ['cloudflare'],
       betweenTestsDelaySec: 10,
       configSource: 'country',
     });
   });
 
-  it('school overrides country', async () => {
+  it('school overrides country (dual provider array)', async () => {
     jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue({
       id: 1,
       giga_id_school: 'sch1',
-      measurement_provider: 'both',
+      measurement_providers: ['mlab', 'cloudflare'],
       between_tests_delay_sec: 5,
       created_at: new Date(),
       updated_at: new Date(),
@@ -80,24 +86,24 @@ describe('ProtocolConfigService', () => {
     jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue({
       id: 2,
       country_code: 'BR',
-      measurement_provider: 'mlab',
+      measurement_providers: ['mlab'],
       between_tests_delay_sec: 99,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
     await expect(service.resolve('sch1', 'BR')).resolves.toEqual({
-      measurementProvider: 'both',
+      measurementProviders: ['mlab', 'cloudflare'],
       betweenTestsDelaySec: 5,
       configSource: 'school',
     });
   });
 
-  it('school row with only delay override inherits provider from country', async () => {
+  it('school row with only delay override inherits providers from country', async () => {
     jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue({
       id: 1,
       giga_id_school: 'sch1',
-      measurement_provider: null,
+      measurement_providers: [],
       between_tests_delay_sec: 7,
       created_at: new Date(),
       updated_at: new Date(),
@@ -105,24 +111,24 @@ describe('ProtocolConfigService', () => {
     jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue({
       id: 2,
       country_code: 'BR',
-      measurement_provider: 'cloudflare',
+      measurement_providers: ['cloudflare'],
       between_tests_delay_sec: 1,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
     await expect(service.resolve('sch1', 'BR')).resolves.toEqual({
-      measurementProvider: 'cloudflare',
+      measurementProviders: ['cloudflare'],
       betweenTestsDelaySec: 7,
       configSource: 'school',
     });
   });
 
-  it('ignores school row when all override columns are null', async () => {
+  it('ignores school row when providers empty and delay null', async () => {
     jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue({
       id: 1,
       giga_id_school: 'sch1',
-      measurement_provider: null,
+      measurement_providers: [],
       between_tests_delay_sec: null,
       created_at: new Date(),
       updated_at: new Date(),
@@ -130,32 +136,34 @@ describe('ProtocolConfigService', () => {
     jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue({
       id: 2,
       country_code: 'BR',
-      measurement_provider: 'cloudflare',
+      measurement_providers: ['cloudflare'],
       between_tests_delay_sec: 2,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
     await expect(service.resolve('sch1', 'BR')).resolves.toEqual({
-      measurementProvider: 'cloudflare',
+      measurementProviders: ['cloudflare'],
       betweenTestsDelaySec: 2,
       configSource: 'country',
     });
   });
 
-  it('coerces invalid DB provider to mlab', async () => {
-    jest.spyOn(prisma.schoolProtocolConfig, 'findUnique').mockResolvedValue(null);
+  it('coerces invalid DB providers to mlab default in country context', async () => {
+    jest
+      .spyOn(prisma.schoolProtocolConfig, 'findUnique')
+      .mockResolvedValue(null);
     jest.spyOn(prisma.countryProtocolConfig, 'findUnique').mockResolvedValue({
       id: 1,
       country_code: 'BR',
-      measurement_provider: 'unknown-provider',
+      measurement_providers: ['unknown-provider'],
       between_tests_delay_sec: 0,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
     await expect(service.resolve(undefined, 'BR')).resolves.toMatchObject({
-      measurementProvider: 'mlab',
+      measurementProviders: ['mlab'],
       configSource: 'country',
     });
   });
@@ -176,7 +184,7 @@ describe('ProtocolConfigService', () => {
     jest.spyOn(prisma.countryProtocolConfig, 'upsert').mockResolvedValue({
       id: 1,
       country_code: 'ES',
-      measurement_provider: 'both',
+      measurement_providers: ['mlab', 'cloudflare'],
       between_tests_delay_sec: 5,
       created_at: createdAt,
       updated_at: updatedAt,
@@ -184,12 +192,12 @@ describe('ProtocolConfigService', () => {
 
     await expect(
       service.upsertCountry('ES', {
-        measurementProvider: 'both',
+        measurementProviders: ['mlab', 'cloudflare'],
         betweenTestsDelaySec: 5,
       }),
     ).resolves.toEqual({
       countryCode: 'ES',
-      measurementProvider: 'both',
+      measurementProviders: ['mlab', 'cloudflare'],
       betweenTestsDelaySec: 5,
       createdAt: createdAt.toISOString(),
       updatedAt: updatedAt.toISOString(),
@@ -201,7 +209,7 @@ describe('ProtocolConfigService', () => {
 
     await expect(
       service.upsertCountry('ZZ', {
-        measurementProvider: 'mlab',
+        measurementProviders: ['mlab'],
         betweenTestsDelaySec: 0,
       }),
     ).rejects.toThrow(NotFoundException);
@@ -212,30 +220,62 @@ describe('ProtocolConfigService', () => {
       count: 0,
     });
 
-    await expect(service.deleteCountry('ES')).rejects.toThrow(NotFoundException);
+    await expect(service.deleteCountry('ES')).rejects.toThrow(
+      NotFoundException,
+    );
   });
 
-  it('upserts school config with partial override', async () => {
+  it('upserts school config with provider override', async () => {
     const createdAt = new Date('2026-05-12T10:00:00.000Z');
     const updatedAt = new Date('2026-05-12T10:00:00.000Z');
     jest.spyOn(prisma.schoolProtocolConfig, 'upsert').mockResolvedValue({
       id: 1,
       giga_id_school: 'sch1',
-      measurement_provider: 'cloudflare',
+      measurement_providers: ['cloudflare'],
       between_tests_delay_sec: null,
       created_at: createdAt,
       updated_at: updatedAt,
     });
 
     await expect(
-      service.upsertSchool('sch1', { measurementProvider: 'cloudflare' }),
+      service.upsertSchool('sch1', { measurementProviders: ['cloudflare'] }),
     ).resolves.toEqual({
       gigaIdSchool: 'sch1',
-      measurementProvider: 'cloudflare',
+      measurementProviders: ['cloudflare'],
       betweenTestsDelaySec: null,
       createdAt: createdAt.toISOString(),
       updatedAt: updatedAt.toISOString(),
     });
+  });
+
+  it('clears school provider override with empty array', async () => {
+    const createdAt = new Date('2026-05-12T10:00:00.000Z');
+    const updatedAt = new Date('2026-05-12T10:00:00.000Z');
+    const upsertSpy = jest
+      .spyOn(prisma.schoolProtocolConfig, 'upsert')
+      .mockResolvedValue({
+        id: 1,
+        giga_id_school: 'sch1',
+        measurement_providers: [],
+        between_tests_delay_sec: null,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+
+    await expect(
+      service.upsertSchool('sch1', { measurementProviders: [] }),
+    ).resolves.toEqual({
+      gigaIdSchool: 'sch1',
+      measurementProviders: [],
+      betweenTestsDelaySec: null,
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+    });
+    expect(upsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ measurement_providers: [] }),
+      }),
+    );
   });
 
   it('throws BadRequestException when school upsert has no fields', async () => {
@@ -249,6 +289,8 @@ describe('ProtocolConfigService', () => {
       count: 0,
     });
 
-    await expect(service.deleteSchool('sch1')).rejects.toThrow(NotFoundException);
+    await expect(service.deleteSchool('sch1')).rejects.toThrow(
+      NotFoundException,
+    );
   });
 });

--- a/src/protocol-config/protocol-config.service.ts
+++ b/src/protocol-config/protocol-config.service.ts
@@ -1,9 +1,13 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpsertCountryProtocolConfigDto } from './protocol-config-upsert-country.dto';
 import { UpsertSchoolProtocolConfigDto } from './protocol-config-upsert-school.dto';
 import {
-  isMeasurementProvider,
+  coerceProviders,
   MeasurementProvider,
   ProtocolConfigSource,
   ResolvedProtocolConfig,
@@ -11,7 +15,7 @@ import {
 
 export interface CountryProtocolConfigRecord {
   countryCode: string;
-  measurementProvider: MeasurementProvider;
+  measurementProviders: MeasurementProvider[];
   betweenTestsDelaySec: number;
   createdAt: string;
   updatedAt: string;
@@ -19,14 +23,15 @@ export interface CountryProtocolConfigRecord {
 
 export interface SchoolProtocolConfigRecord {
   gigaIdSchool: string;
-  measurementProvider: MeasurementProvider | null;
+  /** Empty array means the school inherits the provider from country / default. */
+  measurementProviders: MeasurementProvider[];
   betweenTestsDelaySec: number | null;
   createdAt: string;
   updatedAt: string;
 }
 
 const DEFAULT_RESOLVED: ResolvedProtocolConfig = {
-  measurementProvider: 'mlab',
+  measurementProviders: ['mlab'],
   betweenTestsDelaySec: 0,
   configSource: 'default',
 };
@@ -35,18 +40,11 @@ const DEFAULT_RESOLVED: ResolvedProtocolConfig = {
 export class ProtocolConfigService {
   constructor(private readonly prisma: PrismaService) {}
 
-  /** Normalize stored DB string to a known provider; invalid values fall back to mlab. */
-  private coerceProvider(raw: string): MeasurementProvider {
-    const v = raw?.trim()?.toLowerCase();
-    if (v && isMeasurementProvider(v)) {
-      return v;
-    }
-    return 'mlab';
-  }
-
   /**
    * Resolve protocol settings with precedence: school -> country -> default.
-   * School row applies only when at least one override column is non-null.
+   * Providers are stored as arrays; the school override applies only when it
+   * carries at least one provider or a delay value. The universal default is
+   * `['mlab']` (mlab is always available).
    */
   async resolve(
     gigaIdSchool?: string | null,
@@ -68,25 +66,33 @@ export class ProtocolConfigService {
         : Promise.resolve(null),
     ]);
 
-    const schoolMeaningful =
-      !!schoolRow &&
-      (schoolRow.measurement_provider != null ||
-        schoolRow.between_tests_delay_sec != null);
-
-    let measurementProvider: MeasurementProvider =
-      DEFAULT_RESOLVED.measurementProvider;
+    let measurementProviders: MeasurementProvider[] = [
+      ...DEFAULT_RESOLVED.measurementProviders,
+    ];
     let betweenTestsDelaySec = DEFAULT_RESOLVED.betweenTestsDelaySec;
     let configSource: ProtocolConfigSource = DEFAULT_RESOLVED.configSource;
 
     if (countryRow) {
-      measurementProvider = this.coerceProvider(countryRow.measurement_provider);
+      const countryProviders = coerceProviders(
+        countryRow.measurement_providers,
+      );
+      measurementProviders = countryProviders.length
+        ? countryProviders
+        : [...DEFAULT_RESOLVED.measurementProviders];
       betweenTestsDelaySec = countryRow.between_tests_delay_sec;
       configSource = 'country';
     }
 
+    const schoolProviders = schoolRow
+      ? coerceProviders(schoolRow.measurement_providers)
+      : [];
+    const schoolMeaningful =
+      !!schoolRow &&
+      (schoolProviders.length > 0 || schoolRow.between_tests_delay_sec != null);
+
     if (schoolMeaningful && schoolRow) {
-      if (schoolRow.measurement_provider != null) {
-        measurementProvider = this.coerceProvider(schoolRow.measurement_provider);
+      if (schoolProviders.length > 0) {
+        measurementProviders = schoolProviders;
       }
       if (schoolRow.between_tests_delay_sec != null) {
         betweenTestsDelaySec = schoolRow.between_tests_delay_sec;
@@ -95,7 +101,7 @@ export class ProtocolConfigService {
     }
 
     return {
-      measurementProvider,
+      measurementProviders,
       betweenTestsDelaySec,
       configSource,
     };
@@ -117,15 +123,20 @@ export class ProtocolConfigService {
       throw new NotFoundException(`Country ${code} not found`);
     }
 
+    const providers = coerceProviders(dto.measurementProviders);
+    if (providers.length === 0) {
+      throw new BadRequestException('measurementProviders must not be empty');
+    }
+
     const row = await this.prisma.countryProtocolConfig.upsert({
       where: { country_code: code },
       create: {
         country_code: code,
-        measurement_provider: dto.measurementProvider,
+        measurement_providers: providers,
         between_tests_delay_sec: dto.betweenTestsDelaySec,
       },
       update: {
-        measurement_provider: dto.measurementProvider,
+        measurement_providers: providers,
         between_tests_delay_sec: dto.betweenTestsDelaySec,
       },
     });
@@ -158,34 +169,30 @@ export class ProtocolConfigService {
       throw new BadRequestException('gigaIdSchool is required');
     }
 
-    if (
-      dto.measurementProvider === undefined &&
-      dto.betweenTestsDelaySec === undefined
-    ) {
+    const providersProvided = dto.measurementProviders !== undefined;
+    const delayProvided = dto.betweenTestsDelaySec !== undefined;
+
+    if (!providersProvided && !delayProvided) {
       throw new BadRequestException(
-        'At least one of measurementProvider or betweenTestsDelaySec is required',
+        'At least one of measurementProviders or betweenTestsDelaySec is required',
       );
     }
 
-    if (
-      dto.measurementProvider != null &&
-      !isMeasurementProvider(dto.measurementProvider)
-    ) {
-      throw new BadRequestException('measurementProvider is invalid');
-    }
+    // `[]` clears the provider override (school inherits from country/default).
+    const providers = providersProvided
+      ? coerceProviders(dto.measurementProviders)
+      : undefined;
 
     const row = await this.prisma.schoolProtocolConfig.upsert({
       where: { giga_id_school: gigaId },
       create: {
         giga_id_school: gigaId,
-        measurement_provider: dto.measurementProvider ?? null,
+        measurement_providers: providers ?? [],
         between_tests_delay_sec: dto.betweenTestsDelaySec ?? null,
       },
       update: {
-        ...(dto.measurementProvider !== undefined
-          ? { measurement_provider: dto.measurementProvider }
-          : {}),
-        ...(dto.betweenTestsDelaySec !== undefined
+        ...(providersProvided ? { measurement_providers: providers } : {}),
+        ...(delayProvided
           ? { between_tests_delay_sec: dto.betweenTestsDelaySec }
           : {}),
       },
@@ -212,14 +219,14 @@ export class ProtocolConfigService {
 
   private mapCountryRow(row: {
     country_code: string;
-    measurement_provider: string;
+    measurement_providers: string[];
     between_tests_delay_sec: number;
     created_at: Date;
     updated_at: Date;
   }): CountryProtocolConfigRecord {
     return {
       countryCode: row.country_code,
-      measurementProvider: row.measurement_provider as MeasurementProvider,
+      measurementProviders: coerceProviders(row.measurement_providers),
       betweenTestsDelaySec: row.between_tests_delay_sec,
       createdAt: row.created_at.toISOString(),
       updatedAt: row.updated_at.toISOString(),
@@ -228,14 +235,14 @@ export class ProtocolConfigService {
 
   private mapSchoolRow(row: {
     giga_id_school: string;
-    measurement_provider: string | null;
+    measurement_providers: string[];
     between_tests_delay_sec: number | null;
     created_at: Date;
     updated_at: Date;
   }): SchoolProtocolConfigRecord {
     return {
       gigaIdSchool: row.giga_id_school,
-      measurementProvider: row.measurement_provider as MeasurementProvider | null,
+      measurementProviders: coerceProviders(row.measurement_providers),
       betweenTestsDelaySec: row.between_tests_delay_sec,
       createdAt: row.created_at.toISOString(),
       updatedAt: row.updated_at.toISOString(),

--- a/src/protocol-config/protocol-config.types.ts
+++ b/src/protocol-config/protocol-config.types.ts
@@ -1,15 +1,39 @@
-export const MEASUREMENT_PROVIDERS = ['mlab', 'cloudflare', 'both'] as const;
+export const MEASUREMENT_PROVIDERS = ['mlab', 'cloudflare'] as const;
 
 export type MeasurementProvider = (typeof MEASUREMENT_PROVIDERS)[number];
 
 export type ProtocolConfigSource = 'school' | 'country' | 'default';
 
 export interface ResolvedProtocolConfig {
-  measurementProvider: MeasurementProvider;
+  measurementProviders: MeasurementProvider[];
   betweenTestsDelaySec: number;
   configSource: ProtocolConfigSource;
 }
 
-export function isMeasurementProvider(value: string): value is MeasurementProvider {
+export function isMeasurementProvider(
+  value: string,
+): value is MeasurementProvider {
   return (MEASUREMENT_PROVIDERS as readonly string[]).includes(value);
+}
+
+/**
+ * Normalize a stored provider list to known providers in canonical order
+ * (mlab, cloudflare), filtering out invalid values and deduplicating.
+ * May return an empty array (e.g. school override absent / all values invalid);
+ * callers decide the fallback for their context.
+ */
+export function coerceProviders(
+  raw: readonly string[] | null | undefined,
+): MeasurementProvider[] {
+  if (!raw) {
+    return [];
+  }
+  const seen = new Set<MeasurementProvider>();
+  for (const value of raw) {
+    const candidate = value?.trim()?.toLowerCase();
+    if (candidate && isMeasurementProvider(candidate)) {
+      seen.add(candidate);
+    }
+  }
+  return MEASUREMENT_PROVIDERS.filter((provider) => seen.has(provider));
 }


### PR DESCRIPTION
…ders

- Updated `CountryProtocolConfig` and `SchoolProtocolConfig` models to use arrays for `measurement_providers`.
- Adjusted DTOs and service methods to handle multiple providers, including validation and coercion logic.
- Modified controller responses to return arrays of providers.
- Updated tests to reflect changes in provider handling and ensure correct functionality.