### PR TITLE
Add country health master field; make leftover renaming changes

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Current state — giga-meter-backend
 
-_Last reviewed: 2026-06-02_
+_Last reviewed: 2026-08-05_
 
 > **Maintainers:** update this file when merging PRs. Do not store PR narratives here — use `/prs/{number}-{slug}.md`. This file is a link-first index, not a full narrative — see [How to keep this current](#how-to-keep-this-current).
 
@@ -16,7 +16,8 @@ _Last reviewed: 2026-06-02_
 | `measurement` | Speed/latency uploads (M-Lab legacy + protocol-specific routes) |
 | `protocol-config` | Country/school protocol resolution and admin CRUD |
 | `school`, `school-master` | Daily Check installations and canonical school data |
-| `country` | Country metadata and API segmentation |
+| `health` | Health facility master records (synced into DB by giga-maps jobs) |
+| `country` | Country metadata; school + health master CDC watermarks |
 | `auth` | API keys, device tokens, HMAC |
 | `connectivity`, `ping-aggregation` | Router ping snapshots and aggregation |
 | `public` | Public/category-filtered read APIs |
@@ -38,6 +39,12 @@ Documented in [ADR 001](./adr/001-dual-protocol-measurements-and-config.md).
 - Resolution: school override → country → default (`protocol-config.service.ts`).
 - Endpoints: `GET /api/v1/protocol-config/resolve`; admin `PUT`/`DELETE` on country and school paths (`protocol-config.controller.ts`).
 - **Legacy removed:** `country_config` table, `MeasurementProvider` enum, and `/api/v1/country-config/*` (Nest module deleted). Do not add a `country-config` module — use `protocol-config` only.
+
+## Health master sync (schema only)
+
+- Master tables: `health`, `master_sync_intermediate_health`, `master_sync_health_static`
+- CDC watermark: `country.latest_health_master_data_version` (parallel to school)
+- Pull/promote jobs: **giga-maps-backend**, not Nest — see [health-master-data-sync-support.md](./health-master-data-sync-support.md)
 
 ## Local data
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ This folder is the **single source of truth** for the **current** state of this 
 | [CURRENT_STATE.md](./CURRENT_STATE.md) | What exists now — start here |
 | [CHANGELOG.md](./CHANGELOG.md) | Append-only log (one line per merged PR) |
 | [adr/](./adr/) | Architecture Decision Records |
+| [health-master-data-sync-support.md](./health-master-data-sync-support.md) | Schema support for health master CDC (giga-maps jobs write `health`) |
+| [health-entity-v1-migration-status.md](./health-entity-v1-migration-status.md) | Health entity Prisma migration checklist |
 
 ## Conventions
 

--- a/docs/health-entity-v1-migration-status.md
+++ b/docs/health-entity-v1-migration-status.md
@@ -12,6 +12,7 @@
 | Phase 2 | `20260521120332_add_health_columns_to_existing_tables` | Adds `entity_type_id`, `registration_id`, `giga_id_health` to `measurements` and `connectivity_ping_checks` with indexes and FKs. |
 | Phase 3 | `20260521124932_add_health_make_school_id_giga_id_nullable` | Makes `measurements.school_id` and `connectivity_ping_checks.giga_id_school` nullable. |
 | Phase 4 | `20260624120000_rename_entity_type_to_facility_type` | Renames `entity_type` → `facility_type`, `entity_type_id` → `facility_type_id`, `country_entity_type_whitelist` → `country_facility_type_whitelist`. |
+| Phase 5 | `20260805180000_add_country_latest_health_master_data_version` | Adds `country.latest_health_master_data_version` for health master CDC (parallel to school watermark). See [health-master-data-sync-support.md](./health-master-data-sync-support.md). |
 
 ---
 
@@ -36,6 +37,7 @@
 | `country` | `+ healths health[]` | 1 | ✅ Done |
 | `country` | `+ master_sync_intermediate_health master_sync_intermediate_health[]` | 1 | ✅ Done |
 | `country` | `+ whitelist_entries country_entity_type_whitelist[]` | 1 | ✅ Done |
+| `country` | `+ latest_health_master_data_version Int?` | 5 | ✅ Done |
 | `measurements` | `+ entity_type_id Int?` | 2 | ✅ Done |
 | `measurements` | `+ registration_id BigInt?` | 2 | ✅ Done |
 | `measurements` | `+ giga_id_health String?` | 2 | ✅ Done |
@@ -51,7 +53,8 @@
 
 | Item | Status | Notes |
 |---|---|---|
-| Seed `entity_type` rows: `{ name: "school" }`, `{ name: "health" }` | ⚠️ **NOT IN MIGRATION** | Design doc requires this in the same migration. Needs a separate seed script or added to Phase 1 SQL manually. |
+| Seed `entity_type` / `facility_type` rows: `{ name: "school" }`, `{ name: "health" }` | ✅ Done later | Seeded in `20260521135124` (codes SCHL/HLTH); normalized to `school`/`health` in `20260727120500_normalize_facility_type_codes`. |
+| `country.latest_health_master_data_version` for master sync watermark | ✅ Phase 5 | Required by giga-maps health master CDC jobs (must not reuse school watermark). |
 | Make `measurements.school_id` nullable | ✅ Phase 3 | |
 | Write `registration` population script from `dailycheckapp_school` | ⏳ Out of scope for migrations | Separate Python script task — not a Prisma migration concern. |
 | Add `entity_type_id` back-fill on migrated `registration` rows | ⏳ Out of scope for migrations | Part of the population script above. |
@@ -72,8 +75,11 @@ The design doc originally described `code` as a future addition (*"add a code va
 ### 3. `country_entity_type_whitelist` uses `country.code` not `country.id`
 The design doc and checklist confirm `country.code` is the correct V1 target. Our implementation is aligned. The design doc notes `master_sync_intermediate` and `master_sync_intermediate_health` still use `country.id` — those are marked as V2 updates and are not changed here.
 
-### 4. Seed data gap
-The design doc checklist requires `entity_type` seed rows (`school`, `health`) to be inserted in the same migration as the table creation. This was not included in Phase 1. The seed data must be applied before any application code attempts to resolve entity types by name. **Action required before going live.**
+### 4. Seed data gap (resolved)
+The design doc checklist required `entity_type` seed rows in Phase 1. They landed later (`20260521135124`) and codes were normalized to `school`/`health` (`20260727120500`). No further seed migration is required for V1 facility types.
+
+### 5. Health master CDC watermark (Phase 5)
+School master sync uses `country.latest_school_master_data_version`. Health master sync needs a **separate** column so the two pipelines do not overwrite each other. Phase 5 adds `latest_health_master_data_version`. Application writers are giga-maps Celery jobs, not Nest request handlers.
 
 ---
 
@@ -82,6 +88,6 @@ The design doc checklist requires `entity_type` seed rows (`school`, `health`) t
 | Item | Notes |
 |---|---|
 | `dailycheckapp_school` → `registration` data migration | Python script, separate task |
-| `entity_type` seed data | Must be added to Phase 1 SQL or run as a standalone script |
-| Application logic changes (endpoints, services) | Outside scope of schema migrations |
+| Delta Sharing load / promote / delete pipeline for health | Owned by **giga-maps-backend** (`proco.giga_meter`), not Nest |
+| Application logic changes (endpoints, services) | Outside scope of schema migrations (health APIs tracked elsewhere) |
 | `master_sync_intermediate` / `master_sync_intermediate_health` country FK standardisation | Deferred to V2 per design doc |

--- a/docs/health-master-data-sync-support.md
+++ b/docs/health-master-data-sync-support.md
@@ -1,0 +1,105 @@
+# Health Master Data Sync — Giga Meter Backend Support
+
+> **Who does what:** The **pull / stage / promote** jobs live in **giga-maps-backend**
+> (`proco/giga_meter/tasks.py`). This NestJS service **owns the database schema**
+> those jobs write into, and the **APIs that read** `health` once data exists.
+>
+> Related giga-maps docs (if you have that repo locally):
+> `proco/giga_meter/docs/health-master-sync-overview.md`
+
+---
+
+## Why Giga Meter Backend needs any change
+
+School master sync already reads/writes:
+
+| Concern | Table / column |
+| -------- | -------------- |
+| Staging | `master_sync_intermediate` |
+| Live facility | `school` |
+| History snapshot | `master_sync_school_static` |
+| “How far did we sync?” | `country.latest_school_master_data_version` |
+
+Health facilities need the same shape. Most of that schema was added in Health Entity V1
+(`health`, `master_sync_intermediate_health`, `master_sync_health_static`).  
+
+The gap: **no health CDC watermark** on `country`, so a health sync job cannot track
+Delta table versions **without colliding with the school watermark**.
+
+---
+
+## What was already done (no further Nest work for master tables)
+
+| Piece | Status |
+| ----- | ------ |
+| `health` table | Done (Phase 1 health migrations) |
+| `master_sync_health_static` | Done |
+| `master_sync_intermediate_health` | Done |
+| Circular FK `health.last_health_static_id` | Done |
+| `facility_type` seeds (`school` / `health`) | Done + codes normalized (`school`/`health`) |
+| Health registration / measurement APIs | Done (read `health`; write registration/measurements) |
+
+Nest does **not** implement Delta Sharing master pull. That is intentional: school master
+sync is owned by giga-maps Celery.
+
+---
+
+## Changes applied for health master sync support
+
+### 1. `country.latest_health_master_data_version` (this work)
+
+| Item | Detail |
+| ---- | ------ |
+| Prisma | `country.latest_health_master_data_version Int?` |
+| Migration | `20260805180000_add_country_latest_health_master_data_version` |
+| Purpose | Per-country incremental version of the health master feed (same role as `latest_school_master_data_version` for schools) |
+| Writer | giga-maps-backend health master sync (not Nest API handlers) |
+| Reader | That same sync job on the next run |
+
+### 2. Test fixtures
+
+- Country mocks that construct full Prisma `country` rows must include the new field
+  (nullable is fine).
+
+---
+
+## What Giga Meter Backend still does **not** own
+
+These remain outside this service (or still need product decisions):
+
+| Item | Owner / note |
+| ---- | ------------ |
+| Delta Sharing health feed config & credentials | Data platform + giga-maps env |
+| Celery load → promote → delete chain | **giga-maps-backend** `tasks.py` / utils / models |
+| Unmanaged Django models for health tables | **giga-maps-backend** |
+| Signature hash rules for `health.signature` | Product + feed owner (promote job or upstream) |
+| Field map feed → `health` vs static | Product + maps sync implementers |
+| Soft-delete impact on registrations | Product |
+| `dailycheckapp_school` → `registration` backfill | Separate migration script (not master sync) |
+
+---
+
+## Deploy notes
+
+1. Apply Prisma migration on the giga-meter DB:
+
+   ```bash
+   npx prisma migrate deploy
+   ```
+
+2. After migrate, giga-maps health sync can store and advance
+   `country.latest_health_master_data_version` without touching school versions.
+
+3. Do not expose this column on public country APIs unless product asks for it — it is
+   an internal CDC bookmark.
+
+---
+
+## Apply order (recommended)
+
+1. **This migration** on shared giga-meter Postgres  
+2. giga-maps: Django unmanaged models for health tables + `latest_health_master_data_version` on `GigaMeter_Country`  
+3. giga-maps: load utils + Celery tasks  
+4. Wire feed config and schedule  
+
+Without step 1, the health sync job has no safe place to store “last version pulled per country.”

--- a/src/prisma/migrations/20260805180000_add_country_latest_health_master_data_version/migration.sql
+++ b/src/prisma/migrations/20260805180000_add_country_latest_health_master_data_version/migration.sql
@@ -1,0 +1,4 @@
+-- Health master sync watermark (parallel to latest_school_master_data_version).
+
+ALTER TABLE "country"
+ADD COLUMN "latest_health_master_data_version" INTEGER;

--- a/src/prisma/migrations/20260805193313_rename_leftover_entity_type_constraints_to_facility_type/migration.sql
+++ b/src/prisma/migrations/20260805193313_rename_leftover_entity_type_constraints_to_facility_type/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "country_facility_type_whitelist" RENAME CONSTRAINT "country_entity_type_whitelist_pkey" TO "country_facility_type_whitelist_pkey";
+
+-- AlterTable
+ALTER TABLE "facility_type" RENAME CONSTRAINT "entity_type_pkey" TO "facility_type_pkey";
+
+-- RenameIndex
+ALTER INDEX "country_facility_type_whitelist_country_code_facility_type_id_k" RENAME TO "country_facility_type_whitelist_country_code_facility_type__key";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -156,6 +156,7 @@ model country {
   created_at                        DateTime                   @default(dbgenerated("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC'::text)")) @db.Timestamptz(6)
   iso3_format                       String?                    @db.VarChar(32)
   latest_school_master_data_version Int?
+  latest_health_master_data_version Int?
   speed_test_protocol               SpeedTestProtocol          @default(NDT7)
   is_active                         Boolean?                   @default(true)
   master_sync_intermediate          master_sync_intermediate[]

--- a/src/protocol-config/protocol-config.service.spec.ts
+++ b/src/protocol-config/protocol-config.service.spec.ts
@@ -343,6 +343,7 @@ describe('ProtocolConfigService', () => {
       created_at: createdAt,
       iso3_format: 'ESP',
       latest_school_master_data_version: 1,
+      latest_health_master_data_version: null,
       speed_test_protocol: SpeedTestProtocol.NDT7,
       is_active: true,
     });


### PR DESCRIPTION
- Add health master CDC watermark and finish facility_type constraint renames
- Add country.latest_health_master_data_version for giga-maps health master
sync, and rename leftover entity_type PK/index names so they match
facility_type.
- Document Giga Meter Backend’s role (schema only).