### PR TITLE
feat: accept upload_failed and schedule context on measurements (v2.0.4)

### DIFF
--- a/src/common/mock-objects.ts
+++ b/src/common/mock-objects.ts
@@ -635,6 +635,9 @@ export const mockMeasurementModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(2),
@@ -680,6 +683,9 @@ export const mockMeasurementModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(3),
@@ -725,6 +731,9 @@ export const mockMeasurementModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
 ];
 
@@ -762,6 +771,9 @@ export const mockMeasurementFailedModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(2),
@@ -796,6 +808,9 @@ export const mockMeasurementFailedModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(3),
@@ -830,6 +845,9 @@ export const mockMeasurementFailedModel = [
     facility_type_id: null,
     registration_id: null,
     giga_id_health: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
 ];
 

--- a/src/measurement/measurement.dto.ts
+++ b/src/measurement/measurement.dto.ts
@@ -731,6 +731,26 @@ export class MeasurementDto {
   @ApiProperty({ required: false })
   wifi_connections?: any[];
 
+  @ApiProperty({
+    required: false,
+    description:
+      'true = the realtime upload failed and the record arrived via offline sync',
+  })
+  upload_failed?: boolean;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Planned slot: 'A' | 'B' | 'C' | 'startup'; null for manual runs",
+  })
+  scheduled_slot?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Originally planned run time of the scheduled test',
+  })
+  scheduled_at?: Date;
+
   @ApiPropertyOptional()
   protocol?: string;
 

--- a/src/measurement/measurement.service.ts
+++ b/src/measurement/measurement.service.ts
@@ -767,6 +767,9 @@ export class MeasurementService {
       wifi_connections: measurement.wifi_connections
         ? JSON.parse(JSON.stringify(measurement.wifi_connections))
         : undefined,
+      upload_failed: measurement.upload_failed,
+      scheduled_slot: measurement.scheduled_slot,
+      scheduled_at: measurement.scheduled_at,
       protocol: measurement.protocol,
       download_latency: measurement.download_latency ?? undefined,
       upload_latency: measurement.upload_latency ?? undefined,
@@ -920,6 +923,9 @@ export class MeasurementService {
       windows_username: measurement.windows_username,
       installed_path: measurement.installed_path,
       wifi_connections: measurement.wifi_connections,
+      upload_failed: measurement.upload_failed ?? false,
+      scheduled_slot: measurement.scheduled_slot ?? null,
+      scheduled_at: measurement.scheduled_at ?? null,
       protocol: measurement.protocol ?? 'mlab',
       download_latency: measurement.download_latency ?? null,
       upload_latency: measurement.upload_latency ?? null,

--- a/src/prisma/migrations/20260807120000_add_upload_failed_and_schedule_context/migration.sql
+++ b/src/prisma/migrations/20260807120000_add_upload_failed_and_schedule_context/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+-- upload_failed: true = the realtime upload from the app failed and the record
+-- arrived later via the offline sync queue.
+-- scheduled_slot / scheduled_at: which slot ('A'|'B'|'C'|'startup', null for
+-- manual runs) and originally planned run time the measurement belongs to.
+ALTER TABLE "measurements" ADD COLUMN     "scheduled_at" TIMESTAMPTZ(6),
+ADD COLUMN     "scheduled_slot" VARCHAR(16),
+ADD COLUMN     "upload_failed" BOOLEAN DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -338,6 +338,9 @@ model measurements {
   facility_type_id             Int?
   registration_id              BigInt?
   giga_id_health               String?
+  upload_failed                Boolean? @default(false) // true = realtime upload failed, record arrived via offline sync
+  scheduled_slot               String?  @db.VarChar(16) // 'A' | 'B' | 'C' | 'startup'; null for manual runs
+  scheduled_at                 DateTime? @db.Timestamptz(6) // originally planned run time of the scheduled test
   facility_type                facility_type?  @relation(fields: [facility_type_id], references: [id])
   registration                 registration? @relation(fields: [registration_id], references: [id])
   @@index([giga_id_school])


### PR DESCRIPTION
Backend side of the v2.0.4 "local test storage flag" item. Frontend counterpart: unicef/project-connect-daily-check-app#83.

## Why

When the Daily Check App's realtime upload fails, the measurement is queued in IndexedDB and re-sent later by the app's periodic sync. Until now those records arrived indistinguishable from realtime uploads, and nothing recorded which scheduled run the measurement belonged to.

## What

Three additive columns on `measurements`:

| Column | Type | Meaning |
|---|---|---|
| `upload_failed` | `boolean`, default `false` | `true` = the realtime upload failed and the record arrived later via the app's offline sync queue |
| `scheduled_slot` | `varchar(16)`, nullable | `'A' \| 'B' \| 'C'` for slot tests, `'startup'` for the daily launch test, `null` for manual runs |
| `scheduled_at` | `timestamptz`, nullable | The originally planned run time, kept even when retries pushed the actual run later |

Both v1 write endpoints (`POST /measurements` and `POST /measurements/multiple`) take `AddMeasurementDto`, which inherits the new optional fields from `MeasurementDto`, so both paths accept them with no controller changes. `toModel()` maps them with safe defaults (`?? false` / `?? null`), so app versions that don't send them are unaffected.

The app sets the flag when it queues the record locally, so no ingestion-side logic is needed to infer it.

## Verification

- Migration applied against a local DB; the three columns are present on `measurements`.
- `prisma migrate diff` (replaying all 41 migrations into a shadow DB vs the schema) shows **no drift attributable to this change** — only pre-existing drift: the `postgis` extension and cosmetic constraint renames left over from the July entity→facility rename.
- Jest: the measurement suites show **the same 39 failures with and without this diff** (verified by stashing), so these are pre-existing on `develop` and this change introduces no regressions. With the diff applied, 34 additional tests run and pass.

## Notes

- `MeasurementV2Dto` intentionally does **not** get the fields — the app still uploads over v1. When measurements move to `/api/v2` with multi-facility, the v2 DTO should be extended too.
- `toFailedModel()` (the `failed_measurements` table) is untouched; its field set is deliberately reduced.

Contract updated in giga `project-memory/api-contracts/measurements-v1.md`. Plan: `0006-local-test-storage-flag-v2.0.4.md`.
