### PR TITLE
feat: accept upload_failed and schedule context on measurements (v2.0.4)

### DIFF
--- a/src/common/mock-objects.ts
+++ b/src/common/mock-objects.ts
@@ -632,6 +632,9 @@ export const mockMeasurementModel = [
     jitter: null,
     packet_loss: null,
     network_quality_score: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(2),
@@ -674,6 +677,9 @@ export const mockMeasurementModel = [
     jitter: null,
     packet_loss: null,
     network_quality_score: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
   {
     id: toBigInt(3),
@@ -716,6 +722,9 @@ export const mockMeasurementModel = [
     jitter: null,
     packet_loss: null,
     network_quality_score: null,
+    upload_failed: false,
+    scheduled_slot: null,
+    scheduled_at: null,
   },
 ];
 

--- a/src/measurement/measurement.dto.ts
+++ b/src/measurement/measurement.dto.ts
@@ -729,6 +729,26 @@ export class MeasurementDto {
   @ApiProperty({ required: false })
   wifi_connections?: any[];
 
+  @ApiProperty({
+    required: false,
+    description:
+      'true = the realtime upload failed and the record arrived via offline sync',
+  })
+  upload_failed?: boolean;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Planned slot: 'A' | 'B' | 'C' | 'startup'; null for manual runs",
+  })
+  scheduled_slot?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Originally planned run time of the scheduled test',
+  })
+  scheduled_at?: Date;
+
   @ApiPropertyOptional()
   protocol?: string;
 

--- a/src/measurement/measurement.service.spec.ts
+++ b/src/measurement/measurement.service.spec.ts
@@ -463,6 +463,56 @@ describe('MeasurementService', () => {
       });
     });
 
+    it('should persist upload_failed and schedule context sent by the app', async () => {
+      jest
+        .spyOn(prisma.dailycheckapp_school, 'findFirst')
+        .mockResolvedValue(mockSchoolModel[0]);
+      jest
+        .spyOn(prisma.giga_id_school_mapping_fix, 'findFirst')
+        .mockResolvedValue(null);
+      const createSpy = jest
+        .spyOn(prisma.measurements, 'create')
+        .mockResolvedValue(mockMeasurementModel[0]);
+
+      const scheduledAt = new Date('2026-08-14T08:23:00.000Z');
+      await service.createMeasurement({
+        ...mockAddMeasurementDto[0],
+        upload_failed: true,
+        scheduled_slot: 'A',
+        scheduled_at: scheduledAt,
+      });
+
+      expect(createSpy).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          upload_failed: true,
+          scheduled_slot: 'A',
+          scheduled_at: scheduledAt,
+        }),
+      });
+    });
+
+    it('should default upload_failed and schedule context when the app omits them', async () => {
+      jest
+        .spyOn(prisma.dailycheckapp_school, 'findFirst')
+        .mockResolvedValue(mockSchoolModel[0]);
+      jest
+        .spyOn(prisma.giga_id_school_mapping_fix, 'findFirst')
+        .mockResolvedValue(null);
+      const createSpy = jest
+        .spyOn(prisma.measurements, 'create')
+        .mockResolvedValue(mockMeasurementModel[0]);
+
+      await service.createMeasurement(mockAddMeasurementDto[0]);
+
+      expect(createSpy).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          upload_failed: false,
+          scheduled_slot: null,
+          scheduled_at: null,
+        }),
+      });
+    });
+
     it('should persist cloudflare protocol and derived quality metrics', async () => {
       jest
         .spyOn(prisma.dailycheckapp_school, 'findFirst')

--- a/src/measurement/measurement.service.ts
+++ b/src/measurement/measurement.service.ts
@@ -467,6 +467,9 @@ export class MeasurementService {
       wifi_connections: measurement.wifi_connections
         ? JSON.parse(JSON.stringify(measurement.wifi_connections))
         : undefined,
+      upload_failed: measurement.upload_failed,
+      scheduled_slot: measurement.scheduled_slot,
+      scheduled_at: measurement.scheduled_at,
       protocol: measurement.protocol,
       download_latency: measurement.download_latency ?? undefined,
       upload_latency: measurement.upload_latency ?? undefined,
@@ -617,6 +620,9 @@ export class MeasurementService {
       windows_username: measurement.windows_username,
       installed_path: measurement.installed_path,
       wifi_connections: measurement.wifi_connections,
+      upload_failed: measurement.upload_failed ?? false,
+      scheduled_slot: measurement.scheduled_slot ?? null,
+      scheduled_at: measurement.scheduled_at ?? null,
       protocol: measurement.protocol ?? 'mlab',
       download_latency: measurement.download_latency ?? null,
       upload_latency: measurement.upload_latency ?? null,

--- a/src/prisma/migrations/20260807120000_add_upload_failed_and_schedule_context/migration.sql
+++ b/src/prisma/migrations/20260807120000_add_upload_failed_and_schedule_context/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+-- upload_failed: true = the realtime upload from the app failed and the record
+-- arrived later via the offline sync queue.
+-- scheduled_slot / scheduled_at: which slot ('A'|'B'|'C'|'startup', null for
+-- manual runs) and originally planned run time the measurement belongs to.
+ALTER TABLE "measurements" ADD COLUMN     "scheduled_at" TIMESTAMPTZ(6),
+ADD COLUMN     "scheduled_slot" VARCHAR(16),
+ADD COLUMN     "upload_failed" BOOLEAN DEFAULT false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -314,6 +314,9 @@ model measurements {
   jitter                      Float?
   packet_loss                 Float?
   network_quality_score       Float?
+  upload_failed               Boolean?  @default(false) // true = realtime upload failed, record arrived via offline sync
+  scheduled_slot              String?   @db.VarChar(16) // 'A' | 'B' | 'C' | 'startup'; null for manual runs
+  scheduled_at                DateTime? @db.Timestamptz(6) // originally planned run time of the scheduled test
   @@index([giga_id_school])
   @@index([country_code])
   @@index([timestamp])


### PR DESCRIPTION
Backend side of the v2.0.4 "local test storage flag" item. Frontend counterpart: unicef/project-connect-daily-check-app#83.

Supersedes #347, which was closed unmerged: that branch was based on `develop`, which is 335 commits ahead of `staging` and carries the unmerged health/facility work. This PR targets `staging` so the change can ship with the v2.0.4 internal release.

## Why

When the Daily Check App's realtime upload fails, the measurement is queued in IndexedDB and re-sent later by the app's periodic sync. Until now those records arrived indistinguishable from realtime uploads, and nothing recorded which scheduled run the measurement belonged to.

## What

Three additive columns on `measurements`:

| Column | Type | Meaning |
|---|---|---|
| `upload_failed` | `boolean`, default `false` | `true` = the realtime upload failed and the record arrived later via the app's offline sync queue |
| `scheduled_slot` | `varchar(16)`, nullable | `'A' \| 'B' \| 'C'` for slot tests, `'startup'` for the daily launch test, `null` for manual runs |
| `scheduled_at` | `timestamptz`, nullable | The originally planned run time, kept even when retries pushed the actual run later |

Both v1 write endpoints (`POST /measurements` and `POST /measurements/multiple`) take `AddMeasurementDto`, which inherits the new optional fields from `MeasurementDto`, so both paths accept them with no controller changes. `toModel()` maps them with safe defaults (`?? false` / `?? null`), so app versions that don't send them are unaffected.

The app sets the flag when it queues the record locally, so no ingestion-side logic is needed to infer it.

## Verification

Re-verified on this `staging`-based branch (the numbers below replace the develop-based ones from #347):

- `prisma validate` passes; Prisma client generates cleanly with the three new fields.
- `tsc --noEmit` over the whole project: clean.
- Jest, measurement suites: **65/65 passing, 4/4 suites green** — unlike `develop`, `staging` has no pre-existing failures here, so the suite is fully green with this diff applied.
- Migration is a plain additive `ALTER TABLE` and sorts last in `staging`'s migration history (previous latest: `20260629120000_change_measurement_provider_to_array`), so it replays in order once `develop`'s July migrations eventually merge in.

## Notes

- `MeasurementV2Dto` intentionally does **not** get the fields — the app still uploads over v1. When measurements move to `/api/v2` with multi-facility, the v2 DTO should be extended too.
- `toFailedModel()` (the `measurements_failed` table) is untouched; its field set is deliberately reduced. On `staging` the failed-measurement mocks have a reduced shape, so unlike #347 they don't carry the new fields.

Contract updated in giga `project-memory/api-contracts/measurements-v1.md`. Plan: `0006-local-test-storage-flag-v2.0.4.md`.
