### PR TITLE
fix: match giga_id_school case-insensitively on measurement upload

### DIFF
--- a/src/measurement/measurement.service.spec.ts
+++ b/src/measurement/measurement.service.spec.ts
@@ -56,6 +56,25 @@ describe('MeasurementService', () => {
       );
     });
 
+    it('should lowercase the giga_id_school filter', async () => {
+      // measurements.giga_id_school is always persisted lowercase, so the
+      // filter has to be normalised or the usage page stays empty for clients
+      // that hold the id in a different casing.
+      const findManySpy = jest
+        .spyOn(prisma.measurements, 'findMany')
+        .mockResolvedValue(mockMeasurementModel);
+
+      await service.measurements(0, 5, 'timestamp', ' TZ-TEST-88001 ');
+
+      expect(findManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            giga_id_school: 'tz-test-88001',
+          }),
+        }),
+      );
+    });
+
     it('should return measurements with lt timestamp filter', async () => {
       jest
         .spyOn(prisma.dailycheckapp_country, 'findFirst')
@@ -401,6 +420,84 @@ describe('MeasurementService', () => {
         mockAddMeasurementDto[0],
       );
       expect(response).toEqual('PCDC school does not exist');
+    });
+
+    it('should match the school regardless of the casing sent by the client', async () => {
+      const schoolSpy = jest
+        .spyOn(prisma.dailycheckapp_school, 'findFirst')
+        .mockResolvedValue(mockSchoolModel[0]);
+      const mappingSpy = jest
+        .spyOn(prisma.giga_id_school_mapping_fix, 'findFirst')
+        .mockResolvedValue(null);
+      jest
+        .spyOn(prisma.measurements, 'create')
+        .mockResolvedValue(mockMeasurementModel[0]);
+
+      // The client sends the id with the casing the schools master returned,
+      // while dailycheckapp_school stores it lowercased.
+      const response = await service.createMeasurement({
+        ...mockAddMeasurementDto[0],
+        giga_id_school: 'TZ-TEST-88001',
+      });
+
+      expect(response).toEqual('');
+      expect(schoolSpy).toHaveBeenCalledWith({
+        where: {
+          giga_id_school: { equals: 'TZ-TEST-88001', mode: 'insensitive' },
+        },
+      });
+      expect(mappingSpy).toHaveBeenCalledWith({
+        where: {
+          giga_id_school_wrong: {
+            equals: 'TZ-TEST-88001',
+            mode: 'insensitive',
+          },
+        },
+      });
+    });
+
+    it('should trim the giga id before looking the school up', async () => {
+      const schoolSpy = jest
+        .spyOn(prisma.dailycheckapp_school, 'findFirst')
+        .mockResolvedValue(mockSchoolModel[0]);
+      jest
+        .spyOn(prisma.giga_id_school_mapping_fix, 'findFirst')
+        .mockResolvedValue(null);
+      jest
+        .spyOn(prisma.measurements, 'create')
+        .mockResolvedValue(mockMeasurementModel[0]);
+
+      await service.createMeasurement({
+        ...mockAddMeasurementDto[0],
+        giga_id_school: '  tz-test-88001  ',
+      });
+
+      expect(schoolSpy).toHaveBeenCalledWith({
+        where: {
+          giga_id_school: { equals: 'tz-test-88001', mode: 'insensitive' },
+        },
+      });
+    });
+
+    it('should leave a missing giga id untouched in the lookup filter', async () => {
+      const schoolSpy = jest
+        .spyOn(prisma.dailycheckapp_school, 'findFirst')
+        .mockResolvedValue(mockSchoolModel[0]);
+      jest
+        .spyOn(prisma.giga_id_school_mapping_fix, 'findFirst')
+        .mockResolvedValue(null);
+      jest
+        .spyOn(prisma.measurements, 'create')
+        .mockResolvedValue(mockMeasurementModel[0]);
+
+      await service.createMeasurement({
+        ...mockAddMeasurementDto[0],
+        giga_id_school: undefined,
+      });
+
+      expect(schoolSpy).toHaveBeenCalledWith({
+        where: { giga_id_school: undefined },
+      });
     });
 
     it('should create failed measurement if wrong country code', async () => {

--- a/src/measurement/measurement.service.ts
+++ b/src/measurement/measurement.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import {
+  Prisma,
   measurements as Measurement,
   measurements_failed as MeasurementFailed,
 } from '@prisma/client';
@@ -318,8 +319,18 @@ export class MeasurementService {
   private async processMeasurement(
     dto: AddMeasurementDto,
   ): Promise<string | null> {
+    // giga_id_school is lowercased whenever a device registers through the API
+    // (SchoolService.toModel), but rows also land in these tables through
+    // hand-written SQL, so the stored casing cannot be trusted. The client
+    // sends the id exactly as the schools master returned it, which for the
+    // Android test schools is uppercase ("TZ-TEST-88001"); an exact match then
+    // rejected every upload with SCHOOL_DOESNT_EXIST_ERR.
+    // A null/undefined id is passed through unchanged to keep the previous
+    // behaviour for measurements submitted without a giga_id_school.
+    const gigaIdFilter = this.caseInsensitiveGigaId(dto.giga_id_school);
+
     const existingRecord = await this.prisma.dailycheckapp_school.findFirst({
-      where: { giga_id_school: dto.giga_id_school },
+      where: { giga_id_school: gigaIdFilter },
     });
 
     if (existingRecord == null) {
@@ -328,7 +339,7 @@ export class MeasurementService {
 
     const gigaSchoolMapping =
       await this.prisma.giga_id_school_mapping_fix.findFirst({
-        where: { giga_id_school_wrong: dto.giga_id_school },
+        where: { giga_id_school_wrong: gigaIdFilter },
       });
 
     if (gigaSchoolMapping != null) {
@@ -340,6 +351,22 @@ export class MeasurementService {
     return null;
   }
 
+  /**
+   * Builds a case-insensitive equality filter for a giga_id_school column.
+   *
+   * Returns the value untouched when it is null/undefined so Prisma keeps
+   * treating it the same way it did before (undefined drops the filter,
+   * null matches NULL rows).
+   */
+  private caseInsensitiveGigaId(
+    giga_id_school?: string,
+  ): Prisma.StringNullableFilter | string | null | undefined {
+    if (giga_id_school == null) {
+      return giga_id_school;
+    }
+    return { equals: giga_id_school.trim(), mode: 'insensitive' };
+  }
+
   private applyFilter(
     giga_id_school?: string,
     filter_by?: string,
@@ -349,7 +376,11 @@ export class MeasurementService {
     countries?: string[],
   ): Record<string, any> {
     const filter: Record<string, any> = {
-      giga_id_school,
+      // measurements.giga_id_school is always persisted lowercase (toModel),
+      // so normalising the incoming value keeps the lookup on the plain
+      // b-tree index instead of falling back to an ILIKE scan of a table
+      // that is orders of magnitude larger than dailycheckapp_school.
+      giga_id_school: giga_id_school?.toLowerCase().trim(),
       country_code: {
         in: countries,
       },


### PR DESCRIPTION
## Problem

Android closed-testing users get a 400 on every measurement upload:

```
Failed to add measurement with error: PCDC school does not exist
```

and the usage page stays empty. Reported for `AndroidTestId1` (TECH-10968).

## Root cause

The backend normalises `giga_id_school` **on write but not on read**.

- **Write:** `SchoolService.toModel()` stores it as `.toLowerCase().trim()`, so device registration always lands in `dailycheckapp_school` lowercase, whatever the client sent.
- **Read:** `MeasurementService.processMeasurement()` looked the school up with an exact, case-sensitive match.

The client is not at fault — it sends the id exactly as `GET /api/v1/schools/country_code_school_id/:country_code/:school_id` returned it, and `SchoolMasterService` returns the master `school` row verbatim. So an uppercase master row produces an uppercase id in the app and a lowercase row in `dailycheckapp_school`, and the two never match.

Real giga ids are lowercase UUIDs, which is why this never surfaced in production. The Android test schools were inserted by hand as `TZ-TEST-88001`, which is what exposed it.

Full chain:

1. App searches the school → master returns `TZ-TEST-88001`.
2. App stores it locally and registers the device.
3. Backend lowercases it → `dailycheckapp_school` holds `tz-test-88001`.
4. App uploads a measurement with `TZ-TEST-88001` (unchanged, from local storage).
5. `processMeasurement` exact-matches → no row → `SCHOOL_DOESNT_EXIST_ERR` → 400 + a row in `measurements_failed`.

## Changes

**`processMeasurement` — case-insensitive comparison.** Applied to both `dailycheckapp_school.giga_id_school` and `giga_id_school_mapping_fix.giga_id_school_wrong`. Rows in both tables are also created by hand, so normalising the *input* would not be enough — the stored casing itself cannot be trusted.

**`applyFilter` — normalise the query parameter instead.** `measurements.giga_id_school` is always persisted lowercase by `toModel()`, so plain equality is exact here and keeps the lookup on the `@@index([giga_id_school])` b-tree rather than falling back to an `ILIKE` scan of a table that is orders of magnitude larger than `dailycheckapp_school`. Without this the usage page stays empty even once uploads start succeeding — easy one to miss.

A `null`/`undefined` `giga_id_school` is passed through untouched, so measurements submitted without one behave exactly as before.

## Testing

- `npx jest` — 442 passed, 63 suites, no regressions.
- 4 new tests: case-insensitive school + mapping lookup, trimming, the null passthrough, and the lowercased `measurements` filter.
- `npx tsc --noEmit` clean.
- `eslint` on both changed files reports only pre-existing prettier violations in untouched regions of `measurement.service.ts` (lines 26, 220-248, 642-646); left alone to keep the diff readable.

## Notes for review

- This implements both points agreed in the Slack thread. Point 1 ("Android should never change the casing of the id") already holds — the app does not touch it — so no app-side change is needed for this bug.
- Once merged, the manual SQL that lowercased the test rows is no longer required, though it does no harm.
- **Separate pre-existing issue, not fixed here:** `giga_id_school` is optional on `AddMeasurementDto` with no validator. When it is absent, Prisma drops the filter, `findFirst` returns an arbitrary row, and the measurement is accepted with a null `giga_id_school`. This PR deliberately preserves that behaviour rather than tightening it. Worth a follow-up ticket.
